### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -34,7 +34,7 @@ class syntax_plugin_headernofloat extends DokuWiki_Syntax_Plugin {
         // header (numbered headers) 45
         function getSort() { return 59; }
  
-        function handle( $match, $state, $pos, &$handler )
+        function handle( $match, $state, $pos, Doku_Handler $handler )
         {
 			// get level and title
 			$title = trim($match);
@@ -56,7 +56,7 @@ class syntax_plugin_headernofloat extends DokuWiki_Syntax_Plugin {
 			return $opts;
         }
  
-        function render( $mode, &$renderer, $data )
+        function render( $mode, Doku_Renderer $renderer, $data )
         {			
 			$title = $text = $data["text"];
 			$level= $data["level"];


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
